### PR TITLE
Remove Node imports  in favor of standard Deno capabilities

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@goog/flow-lens",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "license": "Apache",
   "exports": "./src/main/main.ts",
   "imports": {

--- a/src/test/flow_file_change_detector_test.ts
+++ b/src/test/flow_file_change_detector_test.ts
@@ -15,7 +15,6 @@
  */
 
 import { assertEquals, assertThrows } from "@std/assert";
-import { Buffer } from "node:buffer";
 import { Configuration } from "../main/argument_processor.ts";
 import { getTestConfig } from "./test_utils.ts";
 import {
@@ -36,9 +35,11 @@ Deno.test("FlowFileChangeDetector", async (t) => {
     (detector as any).executeVersionCommand = () => undefined;
     (detector as any).executeRevParseCommand = () => undefined;
     (detector as any).executeDiffCommand = () =>
-      Buffer.from(["file1.txt", FLOW_FILE_PATH, "file3.js"].join(EOL));
+      new TextEncoder().encode(
+        ["file1.txt", FLOW_FILE_PATH, "file3.js"].join(EOL),
+      );
     (detector as any).executeGetFileContentCommand = () =>
-      Buffer.from("file content");
+      new TextEncoder().encode("file content");
     // tslint:enable:no-any
   };
 

--- a/src/test/flow_parser_test.ts
+++ b/src/test/flow_parser_test.ts
@@ -14,32 +14,27 @@
  * limitations under the License.
  */
 
-import * as fs from "node:fs";
-import * as path from "node:path";
+import { join } from "@std/path";
 import { ERROR_MESSAGES, FlowParser, ParsedFlow } from "../main/flow_parser.ts";
 import * as flowTypes from "../main/flow_types.ts";
 import { assert, assertEquals, assertRejects } from "@std/assert";
 
-const ENCODING = "utf8";
 const GOLDENS_PATH = "./src/test/goldens";
 const LOOP_NODE_NAME = "myLoop";
 const NON_EXISTING_ELEMENT = "Non_Existing_Element";
 const START_NODE_NAME = "FLOW_START";
 
 const TEST_FILES = {
-  multipleElements: path.join(GOLDENS_PATH, "multiple_elements.flow-meta.xml"),
-  singleElements: path.join(GOLDENS_PATH, "single_elements.flow-meta.xml"),
-  sample: path.join(GOLDENS_PATH, "sample.flow-meta.xml"),
-  noStartNode: path.join(GOLDENS_PATH, "no_start_node.flow-meta.xml"),
-  missingTransitionNode: path.join(
+  multipleElements: join(GOLDENS_PATH, "multiple_elements.flow-meta.xml"),
+  singleElements: join(GOLDENS_PATH, "single_elements.flow-meta.xml"),
+  sample: join(GOLDENS_PATH, "sample.flow-meta.xml"),
+  noStartNode: join(GOLDENS_PATH, "no_start_node.flow-meta.xml"),
+  missingTransitionNode: join(
     GOLDENS_PATH,
     "missing_transition_node.flow-meta.xml",
   ),
-  circularTransition: path.join(
-    GOLDENS_PATH,
-    "circular_transition.flow-meta.xml",
-  ),
-  rollback: path.join(GOLDENS_PATH, "rollback.flow-meta.xml"),
+  circularTransition: join(GOLDENS_PATH, "circular_transition.flow-meta.xml"),
+  rollback: join(GOLDENS_PATH, "rollback.flow-meta.xml"),
 };
 
 const NODE_NAMES = {
@@ -68,9 +63,7 @@ Deno.test("FlowParser", async (t) => {
   let parsedFlow: ParsedFlow;
 
   await t.step("should parse valid XML into a flow object", async () => {
-    systemUnderTest = new FlowParser(
-      fs.readFileSync(TEST_FILES.sample, ENCODING),
-    );
+    systemUnderTest = new FlowParser(Deno.readTextFileSync(TEST_FILES.sample));
 
     parsedFlow = await systemUnderTest.generateFlowDefinition();
 
@@ -118,7 +111,7 @@ Deno.test("FlowParser", async (t) => {
 
   await t.step("should handle circular transitions", async () => {
     systemUnderTest = new FlowParser(
-      fs.readFileSync(TEST_FILES.circularTransition, ENCODING),
+      Deno.readTextFileSync(TEST_FILES.circularTransition),
     );
 
     parsedFlow = await systemUnderTest.generateFlowDefinition();
@@ -145,7 +138,7 @@ Deno.test("FlowParser", async (t) => {
     "should ensure multiple node definitions are represented as arrays",
     async () => {
       systemUnderTest = new FlowParser(
-        fs.readFileSync(TEST_FILES.multipleElements, ENCODING),
+        Deno.readTextFileSync(TEST_FILES.multipleElements),
       );
 
       parsedFlow = await systemUnderTest.generateFlowDefinition();
@@ -228,7 +221,7 @@ Deno.test("FlowParser", async (t) => {
     "should ensure single node definitions are represented as arrays",
     async () => {
       systemUnderTest = new FlowParser(
-        fs.readFileSync(TEST_FILES.singleElements, ENCODING),
+        Deno.readTextFileSync(TEST_FILES.singleElements),
       );
 
       parsedFlow = await systemUnderTest.generateFlowDefinition();
@@ -308,7 +301,7 @@ Deno.test("FlowParser", async (t) => {
 
   await t.step("should properly identify rollbacks", async () => {
     systemUnderTest = new FlowParser(
-      fs.readFileSync(TEST_FILES.rollback, ENCODING),
+      Deno.readTextFileSync(TEST_FILES.rollback),
     );
 
     parsedFlow = await systemUnderTest.generateFlowDefinition();
@@ -371,7 +364,7 @@ Deno.test("FlowParser", async (t) => {
     "should throw an error when the XML is missing a start node",
     async () => {
       systemUnderTest = new FlowParser(
-        fs.readFileSync(TEST_FILES.noStartNode, ENCODING),
+        Deno.readTextFileSync(TEST_FILES.noStartNode),
       );
 
       await assertRejects(
@@ -386,7 +379,7 @@ Deno.test("FlowParser", async (t) => {
     "should throw an error when the XML contains an invalid transition",
     async () => {
       systemUnderTest = new FlowParser(
-        fs.readFileSync(TEST_FILES.missingTransitionNode, ENCODING),
+        Deno.readTextFileSync(TEST_FILES.missingTransitionNode),
       );
 
       await assertRejects(

--- a/src/test/flow_to_uml_transformer_test.ts
+++ b/src/test/flow_to_uml_transformer_test.ts
@@ -20,7 +20,6 @@ import {
   assertExists,
   assertStringIncludes,
 } from "@std/assert";
-import * as fs from "node:fs";
 import { Configuration, DiagramTool } from "../main/argument_processor.ts";
 import { getTestConfig } from "./test_utils.ts";
 import { FlowFileChangeDetector } from "../main/flow_file_change_detector.ts";
@@ -42,13 +41,14 @@ Deno.test("FlowToUmlTransformer", async (t) => {
   let result: Map<string, FlowDifference>;
 
   await t.step("setup", () => {
-    // Mock the private methods which execute git commands using spyOn
-    const executeGetFileContentCommand = () => {
-      return fs.readFileSync(SAMPLE_FLOW_FILE_PATH, "utf8");
+    // Mock the private method which executes git commands using spyOn
+    const executeGitCommand = () => {
+      return new TextEncoder().encode(
+        Deno.readTextFileSync(SAMPLE_FLOW_FILE_PATH),
+      );
     };
     // Replace the private method with our mock implementation, using type assertion to access it.
-    (CHANGE_DETECTOR as any).executeGetFileContentCommand =
-      executeGetFileContentCommand;
+    (CHANGE_DETECTOR as any).executeGitCommand = executeGitCommand;
   });
 
   await t.step("should transform a flow file to a UML diagram", async () => {

--- a/src/test/main_test.ts
+++ b/src/test/main_test.ts
@@ -15,7 +15,7 @@
  */
 
 import { assert, assertEquals, assertExists } from "@std/assert";
-import * as path from "node:path";
+import { join } from "@std/path";
 import {
   Configuration,
   DiagramTool,
@@ -56,6 +56,6 @@ Deno.test(
     assert(runner.filePathToFlowDifference.has(SAMPLE_FLOW_FILE_PATH));
     assertExists(runner.filePathToFlowDifference.get(SAMPLE_FLOW_FILE_PATH));
 
-    await Deno.remove(path.join(TEST_UNDECLARED_OUTPUTS_DIR, "test.json"));
+    await Deno.remove(join(TEST_UNDECLARED_OUTPUTS_DIR, "test.json"));
   },
 );


### PR DESCRIPTION
- Replace Node.js Buffer with Deno's Uint8Array for file content handling in FlowFileChangeDetector.
- Refactor FlowToUmlTransformer to utilize Deno's path module for file path handling.
- Simplify git command execution by introducing a new executeGitCommand method.
- Update error message functions to use TypeScript's string return type.
- Enhance test cases to align with Deno's file reading methods, ensuring compatibility and consistency across tests.